### PR TITLE
Changed column names of scheme tables to match rest of codebase

### DIFF
--- a/R/naaccr_factor.R
+++ b/R/naaccr_factor.R
@@ -20,8 +20,8 @@ naaccr_factor <- function(x, field, ...) {
   if (length(field) != 1L) {
     stop("field should be single string")
   }
-  if (field %in% field_code_scheme[["xml_name"]]) {
-    field_scheme <- field_code_scheme[list(xml_name = field), on = "xml_name"]
+  if (field %in% field_code_scheme[["name"]]) {
+    field_scheme <- field_code_scheme[list(name = field), on = "name"]
     codes <- field_codes[field_scheme, on = "scheme"]
     setorderv(codes, "code")
     factor(x, levels = codes[["code"]], labels = codes[["label"]], ...)
@@ -61,8 +61,8 @@ split_sentineled <- function(x, field) {
   if (length(field) != 1L) {
     stop("field should be single string")
   }
-  if (field %in% field_sentinel_scheme[["xml_name"]]) {
-    field_scheme <- field_sentinel_scheme[list(field), on = "xml_name"]
+  if (field %in% field_sentinel_scheme[["name"]]) {
+    field_scheme <- field_sentinel_scheme[list(field), on = "name"]
     sents <- field_sentinels[field_scheme, on = "scheme"]
     setorderv(sents, "sentinel")
     x <- as.character(x)

--- a/R/write_naaccr.R
+++ b/R/write_naaccr.R
@@ -6,7 +6,7 @@ naaccr_unfactor <- function(x, field) {
   if (length(field) != 1L) {
     stop("field should be single string")
   }
-  field_scheme <- field_code_scheme[list(xml_name = field), on = "xml_name"]
+  field_scheme <- field_code_scheme[list(name = field), on = "name"]
   if (nrow(field_scheme) != 1L) {
     stop(field, " matched ", nrow(field_scheme), " schema")
   }
@@ -37,7 +37,7 @@ naaccr_unsentinel <- function(value,
   if (length(field) != 1L) {
     stop("field should be single string")
   }
-  field_scheme <- field_sentinel_scheme[list(xml_name = field), on = "xml_name"]
+  field_scheme <- field_sentinel_scheme[list(name = field), on = "name"]
   if (nrow(field_scheme) != 1L) {
     stop(field, " matched ", nrow(field_scheme), " schema")
   }

--- a/data-raw/field_code_scheme.csv
+++ b/data-raw/field_code_scheme.csv
@@ -1,4 +1,4 @@
-xml_name,scheme
+name,scheme
 addrAtDxCountry,iso_country
 addrAtDxState,state
 addrCurrentCountry,iso_country

--- a/data-raw/field_sentinel_scheme.csv
+++ b/data-raw/field_sentinel_scheme.csv
@@ -1,4 +1,4 @@
-xml_name,scheme
+name,scheme
 adenoidCysticBasaloidPattern,adenoidCysticBasaloidPattern
 afpPostOrchiectomyLabValue,afp_lab_value
 afpPreOrchiectomyLabValue,afp_lab_value


### PR DESCRIPTION
All official NAACCR field names are now labeled `name` in the code base.
Stopped using `xml_name`.