### PR TITLE
Speed up reading and writing files

### DIFF
--- a/R/naaccr_factor.R
+++ b/R/naaccr_factor.R
@@ -94,7 +94,6 @@ naaccr_factor <- function(x, field, keep_unknown = FALSE, ...) {
   if (field %in% field_code_scheme[["name"]]) {
     field_scheme <- field_code_scheme[list(name = field), on = "name"]
     codes <- field_codes[field_scheme, on = "scheme"]
-    setorderv(codes, "code")
     out <- factor(x, levels = codes[["code"]], labels = codes[["label"]], ...)
     if (isFALSE(keep_unknown)) {
       out <- unknown_to_na(out, field = field)
@@ -138,7 +137,6 @@ split_sentineled <- function(x, field) {
   if (field %in% field_sentinel_scheme[["name"]]) {
     field_scheme <- field_sentinel_scheme[list(field), on = "name"]
     sents <- field_sentinels[field_scheme, on = "scheme"]
-    setorderv(sents, "sentinel")
     x <- as.character(x)
     x <- trimws(x)
     is_empty <- !nzchar(x)

--- a/R/read_naaccr.R
+++ b/R/read_naaccr.R
@@ -141,7 +141,6 @@ read_naaccr_plain <- function(input,
   if (!is.null(version)) {
     key_data <- list(version = version)
     read_format <- naaccr_format[key_data, on = "version"]
-    setorderv(read_format, "item")
   } else if (!is.null(format)) {
     read_format <- format
   } else {

--- a/R/read_naaccr.R
+++ b/R/read_naaccr.R
@@ -54,22 +54,11 @@ split_fields <- function(record_lines,
   if (!is.null(col_names) && length(start_cols) != length(col_names)) {
     stop("start_cols and end_cols must be the same length")
   }
-  item_matrix <- mapply(
-    FUN      = stringi::stri_sub,
-    from     = start_cols,
-    to       = end_cols,
-    MoreArgs = list(str = record_lines),
-    SIMPLIFY = FALSE
-  )
-  setDT(item_matrix)
+  item_matrix <- stringi::stri_sub_all(record_lines, start_cols, end_cols)
+  item_matrix <- do.call(rbind, item_matrix)
+  item_matrix[] <- stringi::stri_trim_both(item_matrix)
+  item_matrix <- as.data.table(item_matrix)
   setnames(item_matrix, col_names)
-  for (column in names(item_matrix)) {
-    set(
-      item_matrix,
-      j = column,
-      value = stringi::stri_trim_both(item_matrix[[column]])
-    )
-  }
   item_matrix
 }
 

--- a/R/record_format.R
+++ b/R/record_format.R
@@ -125,11 +125,11 @@ type_converters <- list(
 #'       County FIPS code.
 #'     }
 #'     \item{\code{Date}}{
-#'       (\code{\link{as.Date}}, with \code{format = "%Y%m%d"})
+#'       (\code{\link{as.Date}}, with \code{format = "\%Y\%m\%d"})
 #'       NAACCR-formatted date (YYYYMMDD).
 #'     }
 #'     \item{\code{datetime}}{
-#'       (\code{\link{as.POSIXct}}, with \code{format = "%Y%m%d%H%M%S"})
+#'       (\code{\link{as.POSIXct}}, with \code{format = "\%Y\%m\%d\%H\%M\%S"})
 #'       NAACCR-formatted datetime (YYYYMMDDHHMMSS)
 #'     }
 #'     \item{\code{facility}}{

--- a/data-raw/create-field_codes.R
+++ b/data-raw/create-field_codes.R
@@ -45,6 +45,8 @@ field_codes <- rbindlist(
 )
 field_codes[, description := NULL]
 field_code_scheme <- fread("data-raw/field_code_scheme.csv")
+setkeyv(field_codes, c("scheme", "code"))
+setkeyv(field_code_scheme, "name")
 save(
   field_codes, field_code_scheme,
   file = "data-raw/sys-data/field_codes.RData",

--- a/data-raw/create-field_sentinels.R
+++ b/data-raw/create-field_sentinels.R
@@ -10,6 +10,8 @@ field_sentinels <- rbindlist(
   idcol = "scheme"
 )
 field_sentinel_scheme <- fread("data-raw/field_sentinel_scheme.csv")
+setkeyv(field_sentinels, c("scheme", "sentinel"))
+setkeyv(field_sentinel_scheme, "name")
 save(
   field_sentinels, field_sentinel_scheme,
   file = "data-raw/sys-data/field_sentinels.RData",


### PR DESCRIPTION
- Use vectorized functions from `stringi` for extracting/rewriting lines
- Read fewer fields in for most tests
- Avoid needless sorting