### PR TITLE
Revert "Remove specification hinting a stricter-than-normal license"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Suggests:
     rmarkdown,
     roxygen2,
     rvest
-License: MIT
+License: MIT + file LICENSE
 Copyright: file COPYRIGHTS
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
Reverts WerthPADOH/naaccr#59