### PR TITLE
Fix naaccr_encode not converting missing values to blanks

### DIFF
--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -1,0 +1,26 @@
+library(testthat)
+library(naaccr)
+
+
+context("Utility functions")
+
+test_that("naaccr_encode properly encodes blanks and NA values", {
+  expect_identical(naaccr_encode("", "countyAtDx"), "   ")
+  expect_identical(naaccr_encode(NA, "countyAtDx"), "   ")
+  expect_identical(naaccr_encode(NA, "dateOfDiagnosis"), "        ")
+  expect_identical(naaccr_encode(NA, "psaLabValue"), "     ")
+  expect_identical(naaccr_encode(NA, "pathDateSpecCollect1"), "              ")
+})
+
+test_that("naaccr_encode uses original date and datetime values", {
+  orig <- list(
+    dateOfBirth = "201208  ",
+    pathDateSpecCollect1 = "2017010115    "
+  )
+  r <- as.naaccr_record(orig, version = 18)
+  for (column in names(orig)) {
+    expected <- orig[[column]]
+    result <- naaccr_encode(r[[column]], column)
+    expect_identical(result, expected)
+  }
+})


### PR DESCRIPTION
This could be a little better if it converted them to codes specifically
meaning "unknown", but that would add a lot of extra logic for not much
benefit. This isn't meant to a package for writing production-ready record
files.