### PR TITLE
Fix padding not being applied in `as.naaccr_record`

### DIFF
--- a/R/naaccr_record.R
+++ b/R/naaccr_record.R
@@ -109,6 +109,18 @@ as.naaccr_record.data.frame <- function(x,
       set(record, j = column, value = as.character(record[[column]]))
     }
   }
+  need_padding <- all_items[["padding"]] != " " & !is.na(all_items[["padding"]])
+  for (pad_col in all_items[["name"]][need_padding]) {
+    set(
+      record,
+      j = pad_col,
+      value = naaccr_encode(
+        x = record[[pad_col]],
+        field = pad_col,
+        format = all_items
+      )
+    )
+  }
   count_items <- all_items[list(type = "count"), on = "type", nomatch = 0L]
   for (ii in seq_len(nrow(count_items))) {
     column <- count_items[["name"]][ii]

--- a/R/write_naaccr.R
+++ b/R/write_naaccr.R
@@ -66,6 +66,7 @@ naaccr_unsentinel <- function(value,
 #' @import stringi
 #' @noRd
 format_decimal <- function(x, width) {
+  x <- as.numeric(x)
   expanded <- formatC(x, width = width, format = "f")
   non_finite <- !is.finite(x)
   if (any(non_finite & !is.na(x))) {
@@ -86,6 +87,7 @@ format_decimal <- function(x, width) {
 #' @import stringi
 #' @noRd
 format_integer <- function(x, width) {
+  x <- as.integer(x)
   expanded <- formatC(x, width = width, format = "d")
   non_finite <- !is.finite(x)
   if (any(non_finite & !is.na(x))) {

--- a/tests/testthat/test-naaccr_record.R
+++ b/tests/testthat/test-naaccr_record.R
@@ -349,3 +349,28 @@ test_that("record_format handles custom cleaning/unknown finding functions", {
   class(expected) <- class(result)
   expect_identical(result, expected)
 })
+
+test_that("Fields with non-blank padding characters get padded", {
+  pad_fmt <- record_format(
+    name = c("foo", "bar", "baz"),
+    item = 1:3,
+    start_col = c(1, 3, 6),
+    end_col = c(2, 5, 9),
+    alignment = c("left", "right", "left"),
+    padding = c(" ", "0", "+"),
+    type = "character"
+  )
+  result <- naaccr_record(
+    foo = c("", NA, "x", "xx"),
+    bar = c("", NA, "x", "xx"),
+    baz = c("", NA, "x", "xx"),
+    format = pad_fmt
+  )
+  expected <- naaccr_record(
+    foo = c(NA, NA, "x", "xx"), # Remember: blanks become BA
+    bar = c(NA, NA, "00x", "0xx"),
+    baz = c(NA, NA, "x+++", "xx++"),
+    format = pad_fmt
+  )
+  expect_identical(result, expected)
+})


### PR DESCRIPTION
Fix padding not being applied in `as.naaccr_record`
Also fixed minor "bug" (unnecessary warnings) with `naaccr_encoding` and integer/numeric fields
given as character vectors.